### PR TITLE
Cmake and assert fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,10 @@ if (CMAKE_VERSION VERSION_LESS "3.1")
 		set (CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 	endif ()
 else ()
-	set (CMAKE_CXX_STANDARD 11)
+	if (NOT CMAKE_CXX_STANDARD)
+		set (CMAKE_CXX_STANDARD 14)
+	endif()
+	
 endif ()
 
 include(GNUInstallDirs)

--- a/nabo/kdtree_cpu.cpp
+++ b/nabo/kdtree_cpu.cpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "nabo_private.h"
 #include "index_heap.h"
+#include <cassert>
 #include <iostream>
 #include <stdexcept>
 #include <limits>

--- a/tests/knnvalidate.cpp
+++ b/tests/knnvalidate.cpp
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "nabo/nabo.h"
 #include "helpers.h"
 //#include "experimental/nabo_experimental.h"
+#include <cassert>
 #include <iostream>
 #include <fstream>
 #include <stdexcept>


### PR DESCRIPTION


The default nabo cmake is overriding the c++ standard to use (to C++11), instead of using that specified by an external project or via the CLI. This is a problem when using newer versions of Eigen, that rely on C++14 or higher.

Current resolution includes a check to make sure the CXX_STANDARD has not been set, and if it has not, it is configured to be C++14 (bumped from 11).

Also included some minor fixes around assertions with newer compilers (eg. On Fedora39 with GCC13).
